### PR TITLE
Exit if run was not queued

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,14 @@ ln -s "${REAL_PLAN_DIR}" "${PLANSHOME}"
   --metadata-branch "${GITHUB_REF#refs/heads/}"     \
   --metadata-commit "${GITHUB_SHA}" | tee run.out
 TGID=$(awk '/run is queued with ID/ {print $10}' <run.out)
+
+# Make sure the we received a run ID
+if [ -z "$TGID" ]
+then
+	echo "${OUTPUT_OUTCOME}failure/not_queued"
+	exit "${FAILURE}"
+fi
+
 echo "${OUTPUT_ID}${TGID}"
 
 echo "Got testground ID ${TGID}"


### PR DESCRIPTION
I've noticed a situation where the action would hang forever (6hrs) if it failed to queue a run.

That's why I think we should exit early if queuing a run failed. I decided to check if `TGID` was empty after scheduling to determine if it worked.

The alternative approach would be to `set -e` on the entire `entrypoint.sh` script. Personally, I'd prefer that but I do not know `testground` CLI well enough to judge if there are any situation in which we'd like to tolerate non-zero exit codes - which would prevent me from introducing this patch fix quickly.

Let me know what you think :) 

###### Testing

Failure case: https://github.com/galargh/go-ipfs/runs/5231923598?check_suite_focus=true
Success case: https://github.com/galargh/go-ipfs/runs/5232065515?check_suite_focus=true